### PR TITLE
home page displays in two seperate columns

### DIFF
--- a/public/sidenav.css
+++ b/public/sidenav.css
@@ -224,6 +224,15 @@ main {
     height: 32vw;
 }
 
+.homewrapper {
+    display: flex;
+    flex-flow: row wrap;
+}
+
+.homesection {
+    width: 45%;
+}
+
 @media only screen and (max-width: 992px) {
     .kenziephoto {
         margin: 1em;
@@ -234,5 +243,8 @@ main {
         object-fit: cover;
         width: 64vw;
         height: 64vw;
+    }
+    .homesection {
+        width: 90%;
     }
 }

--- a/views/signup.pug
+++ b/views/signup.pug
@@ -5,44 +5,45 @@ html
         body
             marquee(behavior="alternate" direction="left" scrollamount="3")
                 img(src="https://i.imgur.com/xhKrJGE.jpg" class="scrolling-header")
-            div.container.section.white
-                //- h1.center.kenzie-lightblue Welcome!
-                div.outline
-                    h4.black-text Sign up here:
-                    p= typeof msg != 'undefined' ? msg : ''
-                    form(method='POST' action='/createProfile' enctype="multipart/form-data")
-                        div.form-group
-                            label(for='name') Username:
-                            input#name.form-control(type='text', placeholder='username' name='name' require)
-                        div.form-group
-                            label(for='password') Password:
-                            input#password.form-control(type='password', placeholder='password' name='password' require)
-                        div.form-group
-                            label(for='confirmPassword') Confirm Password:
-                            input#confirmPassword.form-control(type='password', placeholder='confirm password' name='confirmPassword' require)
-                        div.file-field.input-field
-                            div.btn.kenzie-lightblue
-                                span Upload Profile Picture:
-                                input(type="file", name="profilePic")
-                            div.file-path-wrapper
-                                input.form-control(class="file-path validate", type="text")
-                        button.btn.kenzie-lightblue.btn-primary(type='submit') Create Profile
-            div.container.section.white
-                //- h2.cyan-text.center Already a member?
-                div.outline
-                    h5 Login here:
-                    p= typeof msg != 'undefined' ? msg : ''
-                    form(method='POST' action='/login')
-                        div.form-group
-                            label(for='name') Name:
-                            input#name.form-control(type='text', placeholder='username' name='name' require)
-                        div.form-group
-                            label(for='password') Password:
-                            input#password.form-control(type='password', placeholder='password' name='password' require)
-                        br
-                        br
-                        button.btn.kenzie-lightblue.btn-primary(type='submit') Login
-                        br
-                        br
+            div.homewrapper
+                div.container.section.white.homesection
+                    //- h1.center.kenzie-lightblue Welcome!
+                    div.outline
+                        h4.black-text Sign up here:
+                        p= typeof msg != 'undefined' ? msg : ''
+                        form(method='POST' action='/createProfile' enctype="multipart/form-data")
+                            div.form-group
+                                label(for='name') Username:
+                                input#name.form-control(type='text', placeholder='username' name='name' require)
+                            div.form-group
+                                label(for='password') Password:
+                                input#password.form-control(type='password', placeholder='password' name='password' require)
+                            div.form-group
+                                label(for='confirmPassword') Confirm Password:
+                                input#confirmPassword.form-control(type='password', placeholder='confirm password' name='confirmPassword' require)
+                            div.file-field.input-field
+                                div.btn.kenzie-lightblue
+                                    span Upload Profile Picture:
+                                    input(type="file", name="profilePic")
+                                div.file-path-wrapper
+                                    input.form-control(class="file-path validate", type="text")
+                            button.btn.kenzie-lightblue.btn-primary(type='submit') Create Profile
+                div.container.section.white.homesection
+                    //- h2.cyan-text.center Already a member?
+                    div.outline
+                        h5 Login here:
+                        p= typeof msg != 'undefined' ? msg : ''
+                        form(method='POST' action='/login')
+                            div.form-group
+                                label(for='name') Name:
+                                input#name.form-control(type='text', placeholder='username' name='name' require)
+                            div.form-group
+                                label(for='password') Password:
+                                input#password.form-control(type='password', placeholder='password' name='password' require)
+                            br
+                            br
+                            button.btn.kenzie-lightblue.btn-primary(type='submit') Login
+                            br
+                            br
     footer
         include includes/footer.pug


### PR DESCRIPTION
Changed home/signup page to display "log in" and "sign up" sections in two columns to minimize scrolling and take advantage of all the extra space.

For screens under 992px it switches back to normal.